### PR TITLE
Inheritance: cosmetic improvements and remaining shortcomings

### DIFF
--- a/Source/Tests/TrackableEntities.Client.Tests.Entities/Mocks/MockNorthwind.cs
+++ b/Source/Tests/TrackableEntities.Client.Tests.Entities/Mocks/MockNorthwind.cs
@@ -29,7 +29,7 @@ namespace TrackableEntities.Client.Tests.Entities.Mocks
             Products = new ChangeTrackingCollection<Product>
                 {
                     new Product { ProductId = 1, ProductName = "Chai", UnitPrice = 21.0000M, Discontinued = false, CategoryId = 1, Category = Categories[0] },
-                    new Product { ProductId = 2, ProductName = "Chang", UnitPrice = 20.0000M, Discontinued = false, CategoryId = 1, Category = Categories[0] },
+                    new PromotionalProduct { ProductId = 2, ProductName = "Chang", UnitPrice = 20.0000M, Discontinued = false, CategoryId = 1, Category = Categories[0], PromoCode = "THAI-EXPO" },
                     new Product { ProductId = 3, ProductName = "Aniseed Syrup", UnitPrice = 10.0000M, Discontinued = false, CategoryId = 2, Category = Categories[1] },
                     new Product { ProductId = 4, ProductName = "Chef Anton's Cajun Seasoning", UnitPrice = 22.0000M, Discontinued = false, CategoryId = 2, Category = Categories[1] },
                     new Product { ProductId = 5, ProductName = "Chef Anton's Gumbo Mix", UnitPrice = 21.3500M, Discontinued = true, CategoryId = 2, Category = Categories[1] },

--- a/Source/Tests/TrackableEntities.Client.Tests.Entities/Mocks/MockNorthwind.cs
+++ b/Source/Tests/TrackableEntities.Client.Tests.Entities/Mocks/MockNorthwind.cs
@@ -28,7 +28,7 @@ namespace TrackableEntities.Client.Tests.Entities.Mocks
                 };
             Products = new ChangeTrackingCollection<Product>
                 {
-                    new Product { ProductId = 1, ProductName = "Chai", UnitPrice = 21.0000M, Discontinued = false, CategoryId = 1, Category = Categories[0] },
+                    new PromotionalProduct { ProductId = 1, ProductName = "Chai", UnitPrice = 21.0000M, Discontinued = false, CategoryId = 1, Category = Categories[0], PromoCode = "SOME-TEE" },
                     new PromotionalProduct { ProductId = 2, ProductName = "Chang", UnitPrice = 20.0000M, Discontinued = false, CategoryId = 1, Category = Categories[0], PromoCode = "THAI-EXPO" },
                     new Product { ProductId = 3, ProductName = "Aniseed Syrup", UnitPrice = 10.0000M, Discontinued = false, CategoryId = 2, Category = Categories[1] },
                     new Product { ProductId = 4, ProductName = "Chef Anton's Cajun Seasoning", UnitPrice = 22.0000M, Discontinued = false, CategoryId = 2, Category = Categories[1] },

--- a/Source/Tests/TrackableEntities.Client.Tests.Entities/NorthwindModels/Product.cs
+++ b/Source/Tests/TrackableEntities.Client.Tests.Entities/NorthwindModels/Product.cs
@@ -1,12 +1,36 @@
 ﻿using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
+using System.ComponentModel;
+using System.Linq.Expressions;
 
 namespace TrackableEntities.Client.Tests.Entities.NorthwindModels
 {
     [JsonObject(IsReference = true)]
-    public class Product : ModelBase<Product>, ITrackable, IEquatable<Product>
+    public class Product : INotifyPropertyChanged, ITrackable, IEquatable<Product>
     {
+        #region Implementation of INotifyPropertyChanged
+
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        protected void NotifyPropertyChanged<TModel, TResult>
+            (TModel dummyThis, Expression<Func<TModel, TResult>> property)
+        {
+            string propertyName = ((MemberExpression)property.Body).Member.Name;
+            if (PropertyChanged != null)
+            {
+                PropertyChanged(this, new PropertyChangedEventArgs(propertyName));
+            }
+        }
+
+        private void NotifyPropertyChanged<TResult>
+            (Expression<Func<Product, TResult>> property)
+        {
+            NotifyPropertyChanged(this, property);
+        }
+
+        #endregion
+
         private int _productId;
         public int ProductId
         {

--- a/Source/Tests/TrackableEntities.Client.Tests.Entities/NorthwindModels/PromotionalProduct.cs
+++ b/Source/Tests/TrackableEntities.Client.Tests.Entities/NorthwindModels/PromotionalProduct.cs
@@ -18,7 +18,7 @@ namespace TrackableEntities.Client.Tests.Entities.NorthwindModels
             {
                 if (value == _giftCode) return;
                 _giftCode = value;
-                NotifyPropertyChanged(m => m.PromoCode);
+                NotifyPropertyChanged(this, m => m.PromoCode);
             }
         }
     }

--- a/Source/Tests/TrackableEntities.Client.Tests.Entities/NorthwindModels/PromotionalProduct.cs
+++ b/Source/Tests/TrackableEntities.Client.Tests.Entities/NorthwindModels/PromotionalProduct.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 namespace TrackableEntities.Client.Tests.Entities.NorthwindModels
 {
     [JsonObject(IsReference = true)]
-    public class PromotionalProduct : Product
+    public class PromotionalProduct : Product, IEquatable<PromotionalProduct>
     {
         private string _giftCode;
         public string PromoCode
@@ -20,6 +20,12 @@ namespace TrackableEntities.Client.Tests.Entities.NorthwindModels
                 _giftCode = value;
                 NotifyPropertyChanged(this, m => m.PromoCode);
             }
+        }
+
+        bool IEquatable<PromotionalProduct>.Equals(PromotionalProduct other)
+        {
+            // Delegate to base IEquatable<Product>
+            return ((IEquatable<Product>)this).Equals(other);
         }
     }
 }

--- a/Source/Tests/TrackableEntities.Client.Tests.Entities/NorthwindModels/PromotionalProduct.cs
+++ b/Source/Tests/TrackableEntities.Client.Tests.Entities/NorthwindModels/PromotionalProduct.cs
@@ -1,0 +1,25 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TrackableEntities.Client.Tests.Entities.NorthwindModels
+{
+    [JsonObject(IsReference = true)]
+    public class PromotionalProduct : Product
+    {
+        private string _giftCode;
+        public string PromoCode
+        {
+            get { return _giftCode; }
+            set
+            {
+                if (value == _giftCode) return;
+                _giftCode = value;
+                NotifyPropertyChanged(m => m.PromoCode);
+            }
+        }
+    }
+}

--- a/Source/Tests/TrackableEntities.Client.Tests.Entities/TrackableEntities.Client.Tests.Entities.csproj
+++ b/Source/Tests/TrackableEntities.Client.Tests.Entities/TrackableEntities.Client.Tests.Entities.csproj
@@ -54,6 +54,7 @@
     <Compile Include="Mocks\MockNorthwind.cs" />
     <Compile Include="NorthwindModels\Area.cs" />
     <Compile Include="NorthwindModels\CustomerSetting.cs" />
+    <Compile Include="NorthwindModels\PromotionalProduct.cs" />
     <Compile Include="NorthwindModels\Territory.cs" />
     <Compile Include="NorthwindModels\Employee.cs" />
     <Compile Include="NorthwindModels\Category.cs" />

--- a/Source/Tests/TrackableEntities.Client.Tests.Extensions/ChangeTrackingExtensionsTests.cs
+++ b/Source/Tests/TrackableEntities.Client.Tests.Extensions/ChangeTrackingExtensionsTests.cs
@@ -472,9 +472,10 @@ namespace TrackableEntities.Client.Tests.Extensions
             // Arrange
             var product = new MockNorthwind().Products.OfType<PromotionalProduct>().First();
             var changeTracker = new ChangeTrackingCollection<PromotionalProduct>(product);
+            var clonedProduct = product.Clone();
 
             // Act
-            changeTracker.MergeChanges();
+            changeTracker.MergeChanges(clonedProduct);
 
             // Assert
             Assert.Pass();

--- a/Source/Tests/TrackableEntities.Client.Tests.Extensions/ChangeTrackingExtensionsTests.cs
+++ b/Source/Tests/TrackableEntities.Client.Tests.Extensions/ChangeTrackingExtensionsTests.cs
@@ -466,6 +466,20 @@ namespace TrackableEntities.Client.Tests.Extensions
             Assert.Pass();
         }
 
+        [Test]
+        public void MergeChanges_On_Equatable_PromotionalProduct_Should_Not_Throw_ArgumentException()
+        {
+            // Arrange
+            var product = new MockNorthwind().Products.OfType<PromotionalProduct>().First();
+            var changeTracker = new ChangeTrackingCollection<PromotionalProduct>(product);
+
+            // Act
+            changeTracker.MergeChanges();
+
+            // Assert
+            Assert.Pass();
+        }
+
         [Test, ExpectedException(typeof(ArgumentException))]
         public void MergeChanges_On_Non_Equatable_Customer_Should_Throw_ArgumentException()
         {

--- a/Source/Tests/TrackableEntities.Client.Tests.Extensions/TrackableExtensionsTests.cs
+++ b/Source/Tests/TrackableEntities.Client.Tests.Extensions/TrackableExtensionsTests.cs
@@ -313,6 +313,9 @@ namespace TrackableEntities.Client.Tests.Extensions
             Assert.AreNotSame(categoryOrig, categoryCopy);
             Assert.AreNotSame(categoryOrig.Products[0], categoryCopy.Products[0]);
             Assert.AreNotSame(categoryOrig.Products[1], categoryCopy.Products[1]);
+            Assert.AreEqual(categoryOrig.Products.Count, categoryCopy.Products.Count);
+            for (int i = 0; i < categoryOrig.Products.Count; ++i)
+                Assert.AreSame(categoryOrig.Products[i].GetType(), categoryCopy.Products[i].GetType());
         }
 
         [Test]

--- a/Source/TrackableEntities.Client/TrackableExtensions.cs
+++ b/Source/TrackableEntities.Client/TrackableExtensions.cs
@@ -433,9 +433,12 @@ namespace TrackableEntities.Client
 
         private static MethodInfo GetEquatableMethod(Type type)
         {
+            string equatableMethod =
+                Constants.EquatableMembers.EquatableMethodStart +
+                type.FullName +
+                Constants.EquatableMembers.EquatableMethodEnd;
             var method = type.GetMethods(BindingFlags.Instance | BindingFlags.NonPublic)
-                .SingleOrDefault(m => m.Name.StartsWith(Constants.EquatableMembers.EquatableMethodStart)
-                    && m.Name.EndsWith(Constants.EquatableMembers.EquatableMethodEnd));
+                .SingleOrDefault(m => m.Name == equatableMethod);
             return method;
         }
 

--- a/Source/TrackableEntities.Client/TrackableExtensions.cs
+++ b/Source/TrackableEntities.Client/TrackableExtensions.cs
@@ -417,9 +417,16 @@ namespace TrackableEntities.Client
             return isManyToManyChild;
         }
 
+        private static IEnumerable<Type> BaseTypes(this Type type)
+        {
+            for (Type t = type; t != null; t = t.BaseType)
+                yield return t;
+        }
+
         private static PropertyInfo GetChangeTrackingProperty(Type entityType, string propertyName)
         {
-            var property = entityType.GetProperties(BindingFlags.Instance | BindingFlags.NonPublic)
+            var property = entityType.BaseTypes()
+                .SelectMany(t => t.GetProperties(BindingFlags.Instance | BindingFlags.NonPublic))
                 .SingleOrDefault(m => m.Name == propertyName + Constants.ChangeTrackingMembers.ChangeTrackingPropEnd);
             return property;
         }
@@ -434,7 +441,8 @@ namespace TrackableEntities.Client
 
         private static PropertyInfo GetEntityIdentifierProperty(Type type)
         {
-            var property = type.GetProperties(BindingFlags.Instance | BindingFlags.NonPublic)
+            var property = type.BaseTypes()
+                .SelectMany(t => t.GetProperties(BindingFlags.Instance | BindingFlags.NonPublic))
                 .SingleOrDefault(m => m.Name == Constants.EquatableMembers.EntityIdentifierProperty);
             return property;
         }

--- a/Source/TrackableEntities.Client/TrackableExtensions.cs
+++ b/Source/TrackableEntities.Client/TrackableExtensions.cs
@@ -289,15 +289,17 @@ namespace TrackableEntities.Client
             {
                 using (var writer = new BsonWriter(stream))
                 {
-                    var setWr = new JsonSerializerSettings { ContractResolver = contractResolver ?? new EntityNavigationPropertyResolver() };
-                    var serWr = JsonSerializer.Create(setWr);
+                    var set = new JsonSerializerSettings();
+                    set.TypeNameHandling = TypeNameHandling.Objects;
+                    set.ContractResolver = contractResolver ?? new EntityNavigationPropertyResolver();
+                    var serWr = JsonSerializer.Create(set);
                     serWr.Serialize(writer, item);
 
                     stream.Position = 0;
                     using (var reader = new BsonReader(stream))
                     {
-                        var setRd = new JsonSerializerSettings { ContractResolver = new EntityNavigationPropertyResolver() };
-                        var serRd = JsonSerializer.Create(setRd);
+                        set.ContractResolver = new EntityNavigationPropertyResolver();
+                        var serRd = JsonSerializer.Create(set);
                         var copy = serRd.Deserialize<T>(reader);
                         return copy;
                     }


### PR DESCRIPTION
Hello Tony and happy new year!

I finally found some time to look at the shortcomings we have with inherited entities. Problems mentioned in http://trackable.codeplex.com/discussions/552553#PostContent_1278793 and http://trackable.codeplex.com/discussions/552553#PostDetailsCell_1278860 still seem to be valid.

I'm currently working on a more radical solution, but for now would like you to have a look at the following PR which fixes a few obvious glitches in
* TrackableExtensions.CloneObject
* TrackableExtensions.GetChangeTrackingProperty
* TrackableExtensions.GetEquatableMethod
* TrackableExtensions.GetEntityIdentifierProperty

It also reveals the shortcoming in the ModelBase class, which doesn't allow us to call its NotifyPropertyChanged method from the inherited entity (commit ac8f8642cd98c5701ded8f77b6710c01bdb61989).

As I said I'm cooking and shooting out a new concept, which will eventually address not only the ModelBase.NotifyPropertyChanged problem, but generally improve the design. Though for now I suggest that we make just a little step (which this PR actually is) and better understand where TE still falls short.

I advise you to read the commit messages top down to follow the story vs. studying just the final diff :)

Best regards,
AZ