### PR TITLE
[Bug] SetModifiedProperties Should Not Affect Parent or Sibling Entities

### DIFF
--- a/Source/Tests/TrackableEntities.Client.Tests/ChangeTrackingCollectionWithChildrenTests.cs
+++ b/Source/Tests/TrackableEntities.Client.Tests/ChangeTrackingCollectionWithChildrenTests.cs
@@ -1298,13 +1298,14 @@ namespace TrackableEntities.Client.Tests
             var changeTracker = new ChangeTrackingCollection<Order>(order);
             var modifiedCustomer = order.Customer;
             modifiedCustomer.CustomerName = "xxx";
+            order.OrderDetails[0].ModifiedProperties = new List<string> { "UnitPrice "};
 
             // Act
             changeTracker.Remove(order);
 
             // Assert
-            Assert.IsTrue(modifiedCustomer.ModifiedProperties == null
-                || modifiedCustomer.ModifiedProperties.Count == 0);
+            Assert.IsTrue(modifiedCustomer.ModifiedProperties.Count == 1);
+            Assert.IsTrue(order.OrderDetails[0].ModifiedProperties == null);
         }
 
         #endregion
@@ -1720,30 +1721,6 @@ namespace TrackableEntities.Client.Tests
             Assert.Contains("Setting", (ICollection)customer.CustomerSetting.ModifiedProperties);
         }
 
-        [Test]
-        public void Existing_Customer_Removed_With_Modified_CustomerSetting_Has_Children_ModifiedProperties_Cleared()
-        {
-            // Arrange
-            var database = new MockNorthwind();
-            var customer = database.Customers[0];
-            customer.CustomerSetting = new CustomerSetting
-            {
-                CustomerId = customer.CustomerId,
-                Setting = "Setting1",
-                Customer = customer
-            };
-            var changeTracker = new ChangeTrackingCollection<Customer>(customer);
-            var modifiedSetting = customer.CustomerSetting;
-            modifiedSetting.Setting = "xxx";
-
-            // Act
-            changeTracker.Remove(customer);
-
-            // Assert
-            Assert.IsTrue(modifiedSetting.ModifiedProperties == null
-                || modifiedSetting.ModifiedProperties.Count == 0);
-        }
-        
         #endregion
 
         #region OneToOne - GetChangesTests

--- a/Source/TrackableEntities.Client/TrackableExtensions.cs
+++ b/Source/TrackableEntities.Client/TrackableExtensions.cs
@@ -115,24 +115,13 @@ namespace TrackableEntities.Client
             if (!visitationHelper.TryVisit(item)) return;
 
             // Iterate entity properties
-            foreach (var navProp in item.GetNavigationProperties())
+            foreach (var colProp in item.GetNavigationProperties().OfCollectionType<ITrackingCollection>())
             {
-                ITrackingCollection trackingCollection = null;
-
-                // 1-M and M-M properties
-                foreach (var colProp in navProp.AsCollectionProperty<ITrackingCollection>())
-                {
-                    trackingCollection = colProp.EntityCollection;
-                }
-
                 // Recursively set modified
-                if (trackingCollection != null)
+                foreach (ITrackable child in colProp.EntityCollection)
                 {
-                    foreach (ITrackable child in trackingCollection)
-                    {
-                        child.SetModifiedProperties(modified, visitationHelper);
-                        child.ModifiedProperties = modified;
-                    }
+                    child.SetModifiedProperties(modified, visitationHelper);
+                    child.ModifiedProperties = modified;
                 }
             }
         }

--- a/Source/TrackableEntities.Client/TrackableExtensions.cs
+++ b/Source/TrackableEntities.Client/TrackableExtensions.cs
@@ -119,12 +119,6 @@ namespace TrackableEntities.Client
             {
                 ITrackingCollection trackingCollection = null;
 
-                // 1-1 and M-1 properties
-                foreach (var refProp in navProp.AsReferenceProperty())
-                {
-                    trackingCollection = item.GetRefPropertyChangeTracker(refProp.Property.Name);
-                }
-
                 // 1-M and M-M properties
                 foreach (var colProp in navProp.AsCollectionProperty<ITrackingCollection>())
                 {


### PR DESCRIPTION
I found and fixed a bug with SetModifiedProperties which has been around a while.  When removing a child entity, ModifiedProperties is cleared from sibling entities because SetModifiedProperties, which is called from RemoveItem in CT collection, sets ModifiedProperties for 1-M and M-M related entities to null.

@azabluda Let me know if you have any thoughts on this.