### PR TITLE
[Bug] DbContext.ApplyChanges Throws Exception when Adding Child M2M Entity

### DIFF
--- a/Source/Tests/TrackableEntities.EF.5.Tests/NorthwindDbContextTests.cs
+++ b/Source/Tests/TrackableEntities.EF.5.Tests/NorthwindDbContextTests.cs
@@ -1043,6 +1043,51 @@ namespace TrackableEntities.EF5.Tests
 		}
 
         [Test]
+        public void Apply_Changes_Should_Mark_Unchanged_Employee_As_Unchanged_And_Added_Territories_Without_Employee_As_Unchanged()
+        {
+            // Arrange
+            var context = TestsHelper.CreateNorthwindDbContext(CreateNorthwindDbOptions);
+            var nw = new MockNorthwind();
+            var employee = nw.Employees[0];
+            var territory1 = employee.Territories[0];
+            territory1.TrackingState = TrackingState.Added;
+
+            // Causes System.InvalidOperationException:
+            // The ObjectStateManager does not contain an ObjectStateEntry with a reference to an object of type 'TrackableEntities.EF.Tests.NorthwindModels.Employee'.
+            territory1.Employees = new List<Employee>();
+
+            // Act
+            context.ApplyChanges(employee);
+
+            // Assert
+            Assert.AreEqual(EntityState.Unchanged, context.Entry(employee).State);
+            Assert.AreEqual(EntityState.Unchanged, context.Entry(territory1).State);
+            Assert.IsTrue(context.RelatedItemHasBeenAdded(employee, territory1));
+        }
+
+        [Test]
+        public void Apply_Changes_Should_Mark_Unchanged_Employee_As_Unchanged_And_Deleted_Territories_Without_Employee_As_Unchanged()
+        {
+            // Arrange
+            var context = TestsHelper.CreateNorthwindDbContext(CreateNorthwindDbOptions);
+            var nw = new MockNorthwind();
+            var employee = nw.Employees[0];
+            var territory1 = employee.Territories[0];
+            territory1.TrackingState = TrackingState.Deleted;
+
+            // Remove employees from territories
+            territory1.Employees = new List<Employee>();
+
+            // Act
+            context.ApplyChanges(employee);
+
+            // Assert
+            Assert.AreEqual(EntityState.Unchanged, context.Entry(employee).State);
+            Assert.AreEqual(EntityState.Unchanged, context.Entry(territory1).State);
+            Assert.IsTrue(context.RelatedItemHasBeenRemoved(employee, territory1));
+        }
+
+        [Test]
         public void Apply_Changes_Should_Mark_Unchanged_Employee_As_Unchanged_And_Unchanged_Territories_With_Modified_Area_As_Modified()
         {
             // Ensure that changes are applied across M-M relationships.

--- a/Source/TrackableEntities.EF.5/DbContextExtensions.cs
+++ b/Source/TrackableEntities.EF.5/DbContextExtensions.cs
@@ -573,6 +573,11 @@ namespace TrackableEntities.EF5
         private static void SetRelationshipState(this DbContext context,
             ITrackable item, ITrackable parent, string propertyName, EntityState entityState)
         {
+            // PR #43: Before calling ChangeRelationshipState make sure parent entry is attached
+            var parentEntry = context.Entry(parent);
+            if (parentEntry.State == EntityState.Detached)
+                parentEntry.State = EntityState.Unchanged;
+
             // Set relationship state for independent association
             var stateManager = ((IObjectContextAdapter)context).ObjectContext.ObjectStateManager;
             stateManager.ChangeRelationshipState(parent, item, propertyName, entityState);


### PR DESCRIPTION
Added failing test in NorthwindDbContextTests:
Apply_Changes_Should_Mark_Unchanged_Employee_As_Unchanged_And_Added_Territories_Without_Employee_As_Unchanged
- Exception thrown when adding child m2m entity without link back to parent.

Exception takes place when setting relationship state of child entities, because parent entity has not yet been attached to context. This bug takes place in v2.2 but not 2.1.