### PR TITLE
Unable to place a new order for an existing product

### DIFF
--- a/Source/Tests/TrackableEntities.EF.5.Tests/NorthwindDbContextTests.cs
+++ b/Source/Tests/TrackableEntities.EF.5.Tests/NorthwindDbContextTests.cs
@@ -402,6 +402,26 @@ namespace TrackableEntities.EF5.Tests
         }
 
         [Test]
+        public void Apply_Changes_Should_Mark_Unchanged_Product_Of_Added_OrderDetail_Of_Added_Order_As_Unchanged()
+        {
+            // Arrange
+            var context = TestsHelper.CreateNorthwindDbContext(CreateNorthwindDbOptions);
+            var order = new MockNorthwind().Orders[0];
+            var orderDetail = order.OrderDetails[0];
+            var product = orderDetail.Product;
+            order.TrackingState = TrackingState.Added;
+            orderDetail.TrackingState = TrackingState.Added;
+
+            // Act
+            context.ApplyChanges(order);
+
+            // Assert
+            Assert.AreEqual(EntityState.Added, context.Entry(order).State);
+            Assert.AreEqual(EntityState.Added, context.Entry(orderDetail).State);
+            Assert.AreEqual(EntityState.Unchanged, context.Entry(product).State);
+        }
+
+        [Test]
         public void Apply_Changes_Should_Mark_Unchanged_Order_With_Multiple_OrderDetails_Added()
         {
             // Arrange


### PR DESCRIPTION
Hi Tony,

Volker has encountered a bug in ApplyChanges yesterday, which I managed to strip down to a relatively simple unit test.

In Northwind terms it is a new Order with one new OrderDetail associated with an existing (unchanged) Product. Exactly how new orders are placed in real life. Strangely ApplyChanges marks Product as Added, which causes EF6 to INSERT it leading to PK index violation.

Could you please look into this problem?

Thanks,
Alexander

P.S: not sure if PR is the right way of submitting problems without any proposed solutions...