### PR TITLE
Remove Method on ChangeTrackingCollection<T>: Disable Change Tracking

### DIFF
--- a/Source/Tests/TrackableEntities.Client.Tests/ChangeTrackingCollectionTests.cs
+++ b/Source/Tests/TrackableEntities.Client.Tests/ChangeTrackingCollectionTests.cs
@@ -435,6 +435,120 @@ namespace TrackableEntities.Client.Tests
                 || product.ModifiedProperties.Count == 0);
         }
 
+        [Test]
+        public void Removed_Items_Should_Disable_Change_Tracking_On_Entity()
+        {
+            // Arrange
+            var database = new MockNorthwind();
+            var order = database.Orders[0];
+
+            var changeTracker = new ChangeTrackingCollection<Order>(order);
+            changeTracker.Remove(order);
+            order.TrackingState = TrackingState.Unchanged;
+
+            // Act
+            order.OrderDate = order.OrderDate.AddDays(1);
+
+            // Assert
+            Assert.AreEqual(TrackingState.Unchanged, order.TrackingState);
+        }
+
+        [Test]
+        public void Removed_Items_Should_Disable_Change_Tracking_On_Related_Entities_OneToMany()
+        {
+            // Arrange
+            var database = new MockNorthwind();
+            var order = database.Orders[0];
+            var detail = order.OrderDetails[0];
+
+            var changeTracker = new ChangeTrackingCollection<Order>(order);
+            changeTracker.Remove(order);
+            detail.TrackingState = TrackingState.Unchanged;
+
+            // Act
+            detail.Quantity++;
+
+            // Assert
+            Assert.AreEqual(TrackingState.Unchanged, detail.TrackingState);
+        }
+
+        [Test]
+        public void Removed_Items_Should_NOT_Disable_Change_Tracking_On_Related_Entities_ManyToOne()
+        {
+            // Arrange
+            var database = new MockNorthwind();
+            var order = database.Orders[0];
+            var customer = order.Customer;
+
+            var changeTracker = new ChangeTrackingCollection<Order>(order);
+            changeTracker.Remove(order);
+
+            // Act
+            customer.CustomerName = "XXX";
+
+            // Assert
+            Assert.AreEqual(TrackingState.Modified, customer.TrackingState);
+        }
+
+        [Test]
+        public void Removed_Items_Should_NOT_Disable_Change_Tracking_On_Related_Entities_OneToOne()
+        {
+            // Arrange
+            var database = new MockNorthwind();
+            var customer = database.Orders[0].Customer;
+            var setting = customer.CustomerSetting = new CustomerSetting
+            {
+                CustomerId = customer.CustomerId,
+                Customer = customer,
+                Setting = "Setting1"
+            };
+
+            var changeTracker = new ChangeTrackingCollection<Customer>(customer);
+            changeTracker.Remove(customer);
+
+            // Act
+            setting.Setting = "XXX";
+
+            // Assert
+            Assert.AreEqual(TrackingState.Modified, setting.TrackingState);
+        }
+
+        [Test]
+        public void Removed_Items_Should_NOT_Disable_Change_Tracking_On_Related_Entities_ManyToMany()
+        {
+            // Arrange
+            var database = new MockNorthwind();
+            var employee = database.Employees[0];
+            var territory = employee.Territories[0];
+
+            var changeTracker = new ChangeTrackingCollection<Employee>(employee);
+            changeTracker.Remove(employee);
+
+            // Act
+            territory.TerritoryDescription = "XXX";
+
+            // Assert
+            Assert.AreEqual(TrackingState.Modified, territory.TrackingState);
+        }
+
+        [Test]
+        public void Removed_Items_Should_NOT_Disable_Change_Tracking_On_Related_Entities_OneToMany_ToOne()
+        {
+            // Arrange
+            var database = new MockNorthwind();
+            var order = database.Orders[0];
+            var product = order.OrderDetails[0].Product;
+
+            var changeTracker = new ChangeTrackingCollection<Order>(order);
+            changeTracker.Remove(order);
+
+            // Act
+            product.ProductName = "XXX";
+
+            // Assert
+            Assert.AreEqual(TrackingState.Modified, product.TrackingState);
+        }
+
         #endregion
 
         #region GetChanges Test

--- a/Source/TrackableEntities.Client/ChangeTrackingCollection.cs
+++ b/Source/TrackableEntities.Client/ChangeTrackingCollection.cs
@@ -90,7 +90,7 @@ namespace TrackableEntities.Client
             }
             set
             {
-                this.SetTracking(value, new ObjectVisitationHelper());
+                SetTracking(value, new ObjectVisitationHelper(), false);
             }
         }
 
@@ -98,7 +98,7 @@ namespace TrackableEntities.Client
         /// For internal use.
         /// Turn change-tracking on and off with proper circular reference checking.
         /// </summary>
-        public void SetTracking(bool value, ObjectVisitationHelper visitationHelper)
+        public void SetTracking(bool value, ObjectVisitationHelper visitationHelper, bool oneToManyOnly)
         {
             ObjectVisitationHelper.EnsureCreated(ref visitationHelper);
 
@@ -116,7 +116,7 @@ namespace TrackableEntities.Client
                 else item.PropertyChanged -= OnPropertyChanged;
 
                 // Enable tracking on trackable collection properties
-                item.SetTracking(value, visitationHelper);
+                item.SetTracking(value, visitationHelper, oneToManyOnly);
 
                 // Set entity identifier
                 if (item is IIdentifiable)
@@ -237,7 +237,7 @@ namespace TrackableEntities.Client
                 item.PropertyChanged -= OnPropertyChanged;
 
                 // Disable tracking on trackable properties
-                item.SetTracking(false, visitationHelper.Clone());
+                item.SetTracking(false, visitationHelper.Clone(), true);
 
                 // Mark item and trackable collection properties
                 item.SetState(TrackingState.Deleted, visitationHelper.Clone());

--- a/Source/TrackableEntities.Client/ITrackingCollection.cs
+++ b/Source/TrackableEntities.Client/ITrackingCollection.cs
@@ -22,7 +22,8 @@ namespace TrackableEntities.Client
         /// <summary>
         /// For internal use.
         /// </summary>
-        void SetTracking(bool value, TrackableEntities.Common.ObjectVisitationHelper visitationHelper);
+        void SetTracking(bool value, Common.ObjectVisitationHelper visitationHelper,
+            bool oneToManyOnly);
 
         /// <summary>
         /// Get entities that have been marked as Added, Modified or Deleted.


### PR DESCRIPTION
When the ```Remove``` method is called on ```ChangeTrackingCollection<T>```, change tracking for related entities is not disabled properly. It should only be disabled for 1-M relations, but not for 1-1, M-1 or M-M.  This is what is causing the problem described in #56.

I have added tests for this desired conditions.  Then I implemented a fix.