### PR TITLE
ApplyChanges should mark grandchild deleted

### DIFF
--- a/Source/Tests/TrackableEntities.EF.5.Tests/FamilyDbContextTests.cs
+++ b/Source/Tests/TrackableEntities.EF.5.Tests/FamilyDbContextTests.cs
@@ -189,5 +189,26 @@ namespace TrackableEntities.EF5.Tests
             Assert.Equal(EntityState.Modified, context.Entry(child2).State);
             Assert.Equal(EntityState.Deleted, context.Entry(child3).State);
         }
+
+        [Fact]
+        public void Apply_Changes_Should_Mark_Grandchild_Deleted()
+        {
+            // Arrange
+            var context = TestsHelper.CreateFamilyDbContext(CreateFamilyDbOptions);
+            var parent = new MockFamily().Parent;
+            var child = parent.Children[0];
+            var grandchild = child.Children[0];
+            parent.TrackingState = TrackingState.Unchanged;
+            child.TrackingState = TrackingState.Deleted;
+            grandchild.TrackingState = TrackingState.Deleted;
+
+            // Act
+            context.ApplyChanges(parent);
+
+            // Assert
+            Assert.Equal(EntityState.Unchanged, context.Entry(parent).State);
+            Assert.Equal(EntityState.Deleted, context.Entry(child).State);
+            Assert.Equal(EntityState.Deleted, context.Entry(grandchild).State);
+        }
     }
 }


### PR DESCRIPTION
Hi Tony,

I've encountered one more issue in ApplyChanges extension method. It fails to propagate State=Deleted into the 2nd level child entity if the 1st level child is also deleted. In the real database scenarios it provokes EF exception in DbContext.SaveChanges
```
System.InvalidOperationException occurred
  HResult=-2146233079
  Message=The operation failed: The relationship could not be changed because one or more of the foreign-key properties is non-nullable. When a change is made to a relationship, the related foreign-key property is set to a null value. If the foreign-key does not support null values, a new relationship must be defined, the foreign-key property must be assigned another non-null value, or the unrelated object must be deleted.
  Source=EntityFramework
  StackTrace:
       at System.Data.Entity.Core.Objects.ObjectContext.PrepareToSaveChanges(SaveOptions options)
       at System.Data.Entity.Core.Objects.ObjectContext.SaveChangesInternal(SaveOptions options, Boolean executeInExistingTransaction)
       at System.Data.Entity.Core.Objects.ObjectContext.SaveChanges(SaveOptions options)
       at System.Data.Entity.Internal.InternalContext.SaveChanges()
       at System.Data.Entity.Internal.LazyInternalContext.SaveChanges()
       at System.Data.Entity.DbContext.SaveChanges()
```
, which looks a bit cryptic but the [solution](http://stackoverflow.com/a/19326114) is quite straightforward - we just need it implemented properly in TE.

I am pushing a failing unit test 'Apply_Changes_Should_Mark_Grandchild_Deleted'. Could you please have a look?

Thank you,
AZ