### PR TITLE
Added test cases demonstrating issues #74 and #75

### DIFF
--- a/Source/Tests/TrackableEntities.Client.Tests.Entities/MultiParentModels/MultiParentChild.cs
+++ b/Source/Tests/TrackableEntities.Client.Tests.Entities/MultiParentModels/MultiParentChild.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TrackableEntities.Client.Tests.Entities.MultiParentModels
+{
+	public class MultiParentChild : EntityBase
+	{
+	}
+}

--- a/Source/Tests/TrackableEntities.Client.Tests.Entities/MultiParentModels/MultiParentRoot.cs
+++ b/Source/Tests/TrackableEntities.Client.Tests.Entities/MultiParentModels/MultiParentRoot.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TrackableEntities.Client.Tests.Entities.MultiParentModels
+{
+	public class MultiParentRoot : EntityBase
+	{
+		public MultiParentRoot()
+		{
+			Parent1Items = new ChangeTrackingCollection<ParentType1>();
+			Parent2Items = new ChangeTrackingCollection<ParentType2>();
+		}
+
+		public ChangeTrackingCollection<ParentType1> Parent1Items { get; set; }
+		public ChangeTrackingCollection<ParentType2> Parent2Items { get; set; }
+	}
+}

--- a/Source/Tests/TrackableEntities.Client.Tests.Entities/MultiParentModels/ParentType1.cs
+++ b/Source/Tests/TrackableEntities.Client.Tests.Entities/MultiParentModels/ParentType1.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TrackableEntities.Client.Tests.Entities.MultiParentModels
+{
+	public class ParentType1 : EntityBase
+	{
+		public ParentType1()
+		{
+			Children = new ChangeTrackingCollection<MultiParentChild>();
+		}
+
+		public ChangeTrackingCollection<MultiParentChild> Children { get; set; }
+	}
+}

--- a/Source/Tests/TrackableEntities.Client.Tests.Entities/MultiParentModels/ParentType2.cs
+++ b/Source/Tests/TrackableEntities.Client.Tests.Entities/MultiParentModels/ParentType2.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TrackableEntities.Client.Tests.Entities.MultiParentModels
+{
+	public class ParentType2 : EntityBase
+	{
+		public ParentType2()
+		{
+			Children = new ChangeTrackingCollection<MultiParentChild>();
+		}
+
+		public ChangeTrackingCollection<MultiParentChild> Children { get; set; }
+	}
+}

--- a/Source/Tests/TrackableEntities.Client.Tests.Entities/TrackableEntities.Client.Tests.Entities.csproj
+++ b/Source/Tests/TrackableEntities.Client.Tests.Entities/TrackableEntities.Client.Tests.Entities.csproj
@@ -51,6 +51,10 @@
     <Compile Include="FamilyModels\Parent.cs" />
     <Compile Include="Mocks\MockFamily.cs" />
     <Compile Include="Mocks\MockNorthwind.cs" />
+    <Compile Include="MultiParentModels\ParentType1.cs" />
+    <Compile Include="MultiParentModels\ParentType2.cs" />
+    <Compile Include="MultiParentModels\MultiParentChild.cs" />
+    <Compile Include="MultiParentModels\MultiParentRoot.cs" />
     <Compile Include="NorthwindModels\Area.cs" />
     <Compile Include="NorthwindModels\CustomerSetting.cs" />
     <Compile Include="NorthwindModels\PriorityOrder.cs" />

--- a/Source/Tests/TrackableEntities.Client.Tests/ChangeTrackingCollectionTests.cs
+++ b/Source/Tests/TrackableEntities.Client.Tests/ChangeTrackingCollectionTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using TrackableEntities.Client.Tests.Entities.Mocks;
+using TrackableEntities.Client.Tests.Entities.MultiParentModels;
 using TrackableEntities.Client.Tests.Entities.NorthwindModels;
 using Xunit;
 
@@ -336,6 +337,39 @@ namespace TrackableEntities.Client.Tests
             Assert.Equal(TrackingState.Unchanged, product.TrackingState);
         }
 
+		[Fact]
+		public void Removed_Added_Items_With_Multiple_Parents_Should_Not_Be_Marked_As_Deleted_Or_Modified()
+		{
+			// Arrange
+			var root = new MultiParentRoot();
+			var changeTracker = new ChangeTrackingCollection<MultiParentRoot>(false);
+			changeTracker.Add(root);
+
+			var parent1 = new ParentType1();
+			root.Parent1Items.Add(parent1);
+
+			var parent2 = new ParentType2();
+			root.Parent2Items.Add(parent2);
+
+			// Act
+			changeTracker.Tracking = true;
+			var childItem = new MultiParentChild();
+			parent1.Children.Add(childItem);
+			parent2.Children.Add(childItem);
+
+			parent1.Children.Remove(childItem);
+			parent2.Children.Remove(childItem);
+
+			// Assert
+			Assert.NotEqual(TrackingState.Deleted, childItem.TrackingState);
+			Assert.NotEqual(TrackingState.Modified, childItem.TrackingState);
+
+			// Alternately, as I don't know a way to ensure that any method that would modify
+			// the TrackingState of a multiple-parent deletion correctly and consistently,
+			// we could test that it was left unaltered as TrackingState.Added
+			//Assert.Equal(TrackingState.Added, childItem.TrackingState);
+		}
+
         [Fact]
         public void Removed_Added_Items_Should_Not_Have_ModifiedProperties()
         {
@@ -624,6 +658,35 @@ namespace TrackableEntities.Client.Tests
             Assert.Equal(TrackingState.Deleted, changes.ElementAt(2).TrackingState);
         }
 
+		[Fact]
+		public void GetChanges_Should_Not_Leave_Restored_Deleted_Items_With_Multiple_Parents_In_Source_Graph()
+		{
+			// Arrange
+			var root = new MultiParentRoot();
+			var changeTracker = new ChangeTrackingCollection<MultiParentRoot>(false);
+			changeTracker.Add(root);
+
+			var parent1 = new ParentType1();
+			root.Parent1Items.Add(parent1);
+
+			var parent2 = new ParentType2();
+			root.Parent2Items.Add(parent2);
+
+			var childItem = new MultiParentChild();
+			parent1.Children.Add(childItem);
+			parent2.Children.Add(childItem);
+
+			// Act
+			changeTracker.Tracking = true;
+			parent1.Children.Remove(childItem);
+			parent2.Children.Remove(childItem);
+
+			var changes = changeTracker.GetChanges();
+
+			// Assert
+			Assert.Equal(0, parent1.Children.Count);
+			Assert.Equal(0, parent2.Children.Count);
+		}
         #endregion
 
         #region EntityChanged Event Tests


### PR DESCRIPTION
Added two new test cases (and a trivial multi-parent model) model:

Removed_Added_Items_With_Multiple_Parents_Should_Not_Be_Marked_As_Deleted_Or_Modified
for issue #74

GetChanges_Should_Not_Leave_Restored_Deleted_Items_With_Multiple_Parents_In_Source_Graph
for issue #75

I've not yet added proposed changes, but as a quick summary of my thoughts:

#74: TrackableEntities.cs, SetState.  For setting a state of Deleted for an Added item, don't modify its state so that it can be removed from multiple collections using the same logic.  ChangeTrackingCollection.cs, RemoveItem is expecting a TrackingState.Added to not add to _deletedEntities already anyway.

#75: TrackableEntities.cs, RemoveRestoredDeletes.  Move the "remove item if marked as deleted" block above the "Prevent endless recursion" line, so that the item is always removed from its parent collection regardless of recursion.