### PR TITLE
Workarounds for Issues #74-75

### DIFF
--- a/Source/Tests/TrackableEntities.Client.Tests.Entities/MultiParentModels/MultiParentChild.cs
+++ b/Source/Tests/TrackableEntities.Client.Tests.Entities/MultiParentModels/MultiParentChild.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TrackableEntities.Client.Tests.Entities.MultiParentModels
+{
+	public class MultiParentChild : EntityBase
+	{
+	}
+}

--- a/Source/Tests/TrackableEntities.Client.Tests.Entities/MultiParentModels/MultiParentRoot.cs
+++ b/Source/Tests/TrackableEntities.Client.Tests.Entities/MultiParentModels/MultiParentRoot.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TrackableEntities.Client.Tests.Entities.MultiParentModels
+{
+	public class MultiParentRoot : EntityBase
+	{
+		public MultiParentRoot()
+		{
+			Parent1Items = new ChangeTrackingCollection<ParentType1>();
+			Parent2Items = new ChangeTrackingCollection<ParentType2>();
+		}
+
+		public ChangeTrackingCollection<ParentType1> Parent1Items { get; set; }
+		public ChangeTrackingCollection<ParentType2> Parent2Items { get; set; }
+	}
+}

--- a/Source/Tests/TrackableEntities.Client.Tests.Entities/MultiParentModels/ParentType1.cs
+++ b/Source/Tests/TrackableEntities.Client.Tests.Entities/MultiParentModels/ParentType1.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TrackableEntities.Client.Tests.Entities.MultiParentModels
+{
+	public class ParentType1 : EntityBase
+	{
+		public ParentType1()
+		{
+			Children = new ChangeTrackingCollection<MultiParentChild>();
+		}
+
+		public ChangeTrackingCollection<MultiParentChild> Children { get; set; }
+	}
+}

--- a/Source/Tests/TrackableEntities.Client.Tests.Entities/MultiParentModels/ParentType2.cs
+++ b/Source/Tests/TrackableEntities.Client.Tests.Entities/MultiParentModels/ParentType2.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TrackableEntities.Client.Tests.Entities.MultiParentModels
+{
+	public class ParentType2 : EntityBase
+	{
+		public ParentType2()
+		{
+			Children = new ChangeTrackingCollection<MultiParentChild>();
+		}
+
+		public ChangeTrackingCollection<MultiParentChild> Children { get; set; }
+	}
+}

--- a/Source/Tests/TrackableEntities.Client.Tests.Entities/TrackableEntities.Client.Tests.Entities.csproj
+++ b/Source/Tests/TrackableEntities.Client.Tests.Entities/TrackableEntities.Client.Tests.Entities.csproj
@@ -51,6 +51,10 @@
     <Compile Include="FamilyModels\Parent.cs" />
     <Compile Include="Mocks\MockFamily.cs" />
     <Compile Include="Mocks\MockNorthwind.cs" />
+    <Compile Include="MultiParentModels\ParentType1.cs" />
+    <Compile Include="MultiParentModels\ParentType2.cs" />
+    <Compile Include="MultiParentModels\MultiParentChild.cs" />
+    <Compile Include="MultiParentModels\MultiParentRoot.cs" />
     <Compile Include="NorthwindModels\Area.cs" />
     <Compile Include="NorthwindModels\CustomerSetting.cs" />
     <Compile Include="NorthwindModels\PriorityOrder.cs" />

--- a/Source/Tests/TrackableEntities.Client.Tests/ChangeTrackingCollectionTests.cs
+++ b/Source/Tests/TrackableEntities.Client.Tests/ChangeTrackingCollectionTests.cs
@@ -342,8 +342,6 @@ namespace TrackableEntities.Client.Tests
 		{
 			// Arrange
 			var root = new MultiParentRoot();
-			var changeTracker = new ChangeTrackingCollection<MultiParentRoot>(false);
-			changeTracker.Add(root);
 
 			var parent1 = new ParentType1();
 			root.Parent1Items.Add(parent1);
@@ -351,23 +349,21 @@ namespace TrackableEntities.Client.Tests
 			var parent2 = new ParentType2();
 			root.Parent2Items.Add(parent2);
 
-			// Act
-			changeTracker.Tracking = true;
-			var childItem = new MultiParentChild();
-			parent1.Children.Add(childItem);
-			parent2.Children.Add(childItem);
+            root.Parent1Items.Tracking = true;
+            root.Parent2Items.Tracking = true;
 
-			parent1.Children.Remove(childItem);
+            var childItem = new MultiParentChild();
+
+            // Act
+            // Work with each parent independently to avoid interference
+            parent1.Children.Add(childItem);
+            parent1.Children.Remove(childItem);
+
+		    parent2.Children.Add(childItem);
 			parent2.Children.Remove(childItem);
 
 			// Assert
-			Assert.NotEqual(TrackingState.Deleted, childItem.TrackingState);
-			Assert.NotEqual(TrackingState.Modified, childItem.TrackingState);
-
-			// Alternately, as I don't know a way to ensure that any method that would modify
-			// the TrackingState of a multiple-parent deletion correctly and consistently,
-			// we could test that it was left unaltered as TrackingState.Added
-			//Assert.Equal(TrackingState.Added, childItem.TrackingState);
+			Assert.Equal(TrackingState.Unchanged, childItem.TrackingState);
 		}
 
         [Fact]
@@ -663,8 +659,6 @@ namespace TrackableEntities.Client.Tests
 		{
 			// Arrange
 			var root = new MultiParentRoot();
-			var changeTracker = new ChangeTrackingCollection<MultiParentRoot>(false);
-			changeTracker.Add(root);
 
 			var parent1 = new ParentType1();
 			root.Parent1Items.Add(parent1);
@@ -676,15 +670,19 @@ namespace TrackableEntities.Client.Tests
 			parent1.Children.Add(childItem);
 			parent2.Children.Add(childItem);
 
-			// Act
-			changeTracker.Tracking = true;
-			parent1.Children.Remove(childItem);
+            root.Parent1Items.Tracking = true;
+            root.Parent2Items.Tracking = true;
+
+            // Act
+            parent1.Children.Remove(childItem);
 			parent2.Children.Remove(childItem);
 
-			var changes = changeTracker.GetChanges();
+            // Work with each parent independently to avoid interference
+            var changes1 = root.Parent1Items.GetChanges();
+            var changes2 = root.Parent2Items.GetChanges();
 
-			// Assert
-			Assert.Equal(0, parent1.Children.Count);
+            // Assert
+            Assert.Equal(0, parent1.Children.Count);
 			Assert.Equal(0, parent2.Children.Count);
 		}
         #endregion

--- a/Source/Tests/TrackableEntities.Client.Tests/ChangeTrackingCollectionTests.cs
+++ b/Source/Tests/TrackableEntities.Client.Tests/ChangeTrackingCollectionTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using TrackableEntities.Client.Tests.Entities.Mocks;
+using TrackableEntities.Client.Tests.Entities.MultiParentModels;
 using TrackableEntities.Client.Tests.Entities.NorthwindModels;
 using Xunit;
 
@@ -336,6 +337,39 @@ namespace TrackableEntities.Client.Tests
             Assert.Equal(TrackingState.Unchanged, product.TrackingState);
         }
 
+		[Fact]
+		public void Removed_Added_Items_With_Multiple_Parents_Should_Not_Be_Marked_As_Deleted_Or_Modified()
+		{
+			// Arrange
+			var root = new MultiParentRoot();
+			var changeTracker = new ChangeTrackingCollection<MultiParentRoot>(false);
+			changeTracker.Add(root);
+
+			var parent1 = new ParentType1();
+			root.Parent1Items.Add(parent1);
+
+			var parent2 = new ParentType2();
+			root.Parent2Items.Add(parent2);
+
+			// Act
+			changeTracker.Tracking = true;
+			var childItem = new MultiParentChild();
+			parent1.Children.Add(childItem);
+			parent2.Children.Add(childItem);
+
+			parent1.Children.Remove(childItem);
+			parent2.Children.Remove(childItem);
+
+			// Assert
+			Assert.NotEqual(TrackingState.Deleted, childItem.TrackingState);
+			Assert.NotEqual(TrackingState.Modified, childItem.TrackingState);
+
+			// Alternately, as I don't know a way to ensure that any method that would modify
+			// the TrackingState of a multiple-parent deletion correctly and consistently,
+			// we could test that it was left unaltered as TrackingState.Added
+			//Assert.Equal(TrackingState.Added, childItem.TrackingState);
+		}
+
         [Fact]
         public void Removed_Added_Items_Should_Not_Have_ModifiedProperties()
         {
@@ -624,6 +658,35 @@ namespace TrackableEntities.Client.Tests
             Assert.Equal(TrackingState.Deleted, changes.ElementAt(2).TrackingState);
         }
 
+		[Fact]
+		public void GetChanges_Should_Not_Leave_Restored_Deleted_Items_With_Multiple_Parents_In_Source_Graph()
+		{
+			// Arrange
+			var root = new MultiParentRoot();
+			var changeTracker = new ChangeTrackingCollection<MultiParentRoot>(false);
+			changeTracker.Add(root);
+
+			var parent1 = new ParentType1();
+			root.Parent1Items.Add(parent1);
+
+			var parent2 = new ParentType2();
+			root.Parent2Items.Add(parent2);
+
+			var childItem = new MultiParentChild();
+			parent1.Children.Add(childItem);
+			parent2.Children.Add(childItem);
+
+			// Act
+			changeTracker.Tracking = true;
+			parent1.Children.Remove(childItem);
+			parent2.Children.Remove(childItem);
+
+			var changes = changeTracker.GetChanges();
+
+			// Assert
+			Assert.Equal(0, parent1.Children.Count);
+			Assert.Equal(0, parent2.Children.Count);
+		}
         #endregion
 
         #region EntityChanged Event Tests


### PR DESCRIPTION
Updated the following tests to illustrate workarounds with children that have multiple parents:

1) Removed_Added_Items_With_Multiple_Parents_Should_Not_Be_Marked_As_Deleted_Or_Modified
2) GetChanges_Should_Not_Leave_Restored_Deleted_Items_With_Multiple_Parents_In_Source_Graph

These tests now both pass as a result of working with multiple change trackers independently.  This is required in order to avoid conflicts among multiple change trackers operating on the same entities.  The reason for this is that Trackable Entities uses change tracking collections rather than a single all-knowing change tracker.  We may change this architecture in a future version of Trackable Entities that is targeted to Entity Framework 7 or later, when we'll likely leverage improved change-tracking facilities of EF7 and use the single change-tracker approach.