### PR TITLE
Load Related Entities for Derived Reference Types

### DIFF
--- a/Source/Tests.Acceptance/TrackableEntities.Tests.Acceptance/TrackableEntities.Tests.Acceptance.csproj
+++ b/Source/Tests.Acceptance/TrackableEntities.Tests.Acceptance/TrackableEntities.Tests.Acceptance.csproj
@@ -110,6 +110,9 @@
     <Compile Include="..\..\Tests\TrackableEntities.EF.5.Tests\NorthwindModels\Employee.cs">
       <Link>NorthwindModels\Employee.cs</Link>
     </Compile>
+    <Compile Include="..\..\Tests\TrackableEntities.EF.5.Tests\NorthwindModels\HolidayPromo.cs">
+      <Link>NorthwindModels\HolidayPromo.cs</Link>
+    </Compile>
     <Compile Include="..\..\Tests\TrackableEntities.EF.5.Tests\NorthwindModels\Order.cs">
       <Link>NorthwindModels\Order.cs</Link>
     </Compile>
@@ -118,6 +121,9 @@
     </Compile>
     <Compile Include="..\..\Tests\TrackableEntities.EF.5.Tests\NorthwindModels\Product.cs">
       <Link>NorthwindModels\Product.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Tests\TrackableEntities.EF.5.Tests\NorthwindModels\Promo.cs">
+      <Link>NorthwindModels\Promo.cs</Link>
     </Compile>
     <Compile Include="..\..\Tests\TrackableEntities.EF.5.Tests\NorthwindModels\Territory.cs">
       <Link>NorthwindModels\Territory.cs</Link>

--- a/Source/Tests/TrackableEntities.EF.5.Tests/Contexts/NorthwindDbContext.cs
+++ b/Source/Tests/TrackableEntities.EF.5.Tests/Contexts/NorthwindDbContext.cs
@@ -38,6 +38,7 @@ namespace TrackableEntities.EF.Tests.Contexts
         
         public DbSet<Category> Categories { get; set; }
         public DbSet<Product> Products { get; set; }
+        public DbSet<Promo> Promos { get; set; }
         public DbSet<Customer> Customers { get; set; }
         public DbSet<CustomerAddress> CustomerAddresses { get; set; }
         public DbSet<CustomerSetting> CustomerSettings { get; set; }
@@ -51,6 +52,8 @@ namespace TrackableEntities.EF.Tests.Contexts
             modelBuilder.Entity<CustomerSetting>()
                 .HasRequired(x => x.Customer)
                 .WithOptional(x => x.CustomerSetting);
+            modelBuilder.Entity<Promo>().ToTable("Promos");
+            modelBuilder.Entity<HolidayPromo>().ToTable("HolidayPromos");
         }
     }
 }

--- a/Source/Tests/TrackableEntities.EF.5.Tests/NorthwindModels/HolidayPromo.cs
+++ b/Source/Tests/TrackableEntities.EF.5.Tests/NorthwindModels/HolidayPromo.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace TrackableEntities.EF.Tests.NorthwindModels
+{
+    public partial class HolidayPromo : Promo, ITrackable
+    {
+        public string HolidayName { get; set; }
+
+        [NotMapped]
+        public TrackingState TrackingState { get; set; }
+        [NotMapped]
+        public ICollection<string> ModifiedProperties { get; set; }
+    }
+}

--- a/Source/Tests/TrackableEntities.EF.5.Tests/NorthwindModels/Product.cs
+++ b/Source/Tests/TrackableEntities.EF.5.Tests/NorthwindModels/Product.cs
@@ -14,6 +14,9 @@ namespace TrackableEntities.EF.Tests.NorthwindModels
         public int CategoryId { get; set; }
         [ForeignKey("CategoryId")]
         public Category Category { get; set; }
+        public int? PromoId { get; set; }
+        [ForeignKey("PromoId")]
+        public HolidayPromo HolidayPromo { get; set; }
 
         [NotMapped]
         public TrackingState TrackingState { get; set; }

--- a/Source/Tests/TrackableEntities.EF.5.Tests/NorthwindModels/Promo.cs
+++ b/Source/Tests/TrackableEntities.EF.5.Tests/NorthwindModels/Promo.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace TrackableEntities.EF.Tests.NorthwindModels
+{
+    public partial class Promo
+    {
+        [Key]
+        public int PromoId { get; set; }
+        public string PromoCode { get; set; }
+    }
+}

--- a/Source/Tests/TrackableEntities.EF.5.Tests/TrackableEntities.EF.5.Tests.csproj
+++ b/Source/Tests/TrackableEntities.EF.5.Tests/TrackableEntities.EF.5.Tests.csproj
@@ -78,6 +78,8 @@
     <Compile Include="Mocks\MockFamily.cs" />
     <Compile Include="Mocks\MockNorthwind.cs" />
     <Compile Include="NorthwindDbInitializer.cs" />
+    <Compile Include="NorthwindModels\HolidayPromo.cs" />
+    <Compile Include="NorthwindModels\Promo.cs" />
     <Compile Include="NorthwindModels\CustomerAddress.cs" />
     <Compile Include="NorthwindModels\Area.cs" />
     <Compile Include="NorthwindModels\CustomerSetting.cs" />

--- a/Source/Tests/TrackableEntities.EF.6.Tests/TrackableEntities.EF.6.Tests.csproj
+++ b/Source/Tests/TrackableEntities.EF.6.Tests/TrackableEntities.EF.6.Tests.csproj
@@ -131,6 +131,9 @@
     <Compile Include="..\TrackableEntities.EF.5.Tests\NorthwindModels\Employee.cs">
       <Link>NorthwindModels\Employee.cs</Link>
     </Compile>
+    <Compile Include="..\TrackableEntities.EF.5.Tests\NorthwindModels\HolidayPromo.cs">
+      <Link>NorthwindModels\HolidayPromo.cs</Link>
+    </Compile>
     <Compile Include="..\TrackableEntities.EF.5.Tests\NorthwindModels\Order.cs">
       <Link>NorthwindModels\Order.cs</Link>
     </Compile>
@@ -139,6 +142,9 @@
     </Compile>
     <Compile Include="..\TrackableEntities.EF.5.Tests\NorthwindModels\Product.cs">
       <Link>NorthwindModels\Product.cs</Link>
+    </Compile>
+    <Compile Include="..\TrackableEntities.EF.5.Tests\NorthwindModels\Promo.cs">
+      <Link>NorthwindModels\Promo.cs</Link>
     </Compile>
     <Compile Include="..\TrackableEntities.EF.5.Tests\NorthwindModels\Territory.cs">
       <Link>NorthwindModels\Territory.cs</Link>


### PR DESCRIPTION
When a type has a reference type which derives from a bass class, then DbContext.LoadRelatedEntities throws an exception because there is a missing table name in the resulting Entity SQL.

I have corrected the problem with this pull request and included a test which verifies the fix.